### PR TITLE
Previous placeTile took a reference so a copy is created 

### DIFF
--- a/NewHaven/src/GBMap.cpp
+++ b/NewHaven/src/GBMap.cpp
@@ -33,6 +33,10 @@ GBMap::~GBMap(){
     delete SIZE;
     delete board;
     delete buildings;
+    delete tl;
+    delete tr;
+    delete bl;
+    delete br;
     // set to nullptr since it is static and belongs to the class.
     current_map = nullptr;
 }
@@ -43,11 +47,11 @@ GBMap::GBMap():CONFIG(new const int(0)), SIZE(new const int(25)),buildings{new s
         // create a proper exception maybe
         throw 1;
 }
-bool GBMap::placeHarvestTile(int NodeID, HarvestTile &tile) {
+bool GBMap::placeHarvestTile(int NodeID, HarvestTile *tile) {
  if(NodeID > *SIZE || NodeID < 0|| &tile == nullptr ||*(*board)[NodeID].isPlayed )
      return false;
     // should use the operator overload
-    (*board)[NodeID].tile = &tile;
+    (*board)[NodeID].tile = tile;
     *(*board)[NodeID].isPlayed = true;
     return true;
 }
@@ -253,18 +257,6 @@ void GBMap::assignDefaultTiles() {
     /*
      * Create 4 tiles
      */
-    ResourceTypes *type1{new ResourceTypes[4]
-    {ResourceTypes::STONE, ResourceTypes ::SHEEP, ResourceTypes::WOOD, ResourceTypes::WOOD}};
-    ResourceTypes *type2{new ResourceTypes[4]
-    {ResourceTypes::WHEAT, ResourceTypes ::SHEEP, ResourceTypes::WHEAT, ResourceTypes::WOOD}};
-    ResourceTypes *type3{new ResourceTypes[4]
-    {ResourceTypes::SHEEP, ResourceTypes ::STONE, ResourceTypes::SHEEP, ResourceTypes::WHEAT}};
-    ResourceTypes *type4{new ResourceTypes[4]
-    {ResourceTypes::STONE, ResourceTypes ::STONE, ResourceTypes::WOOD, ResourceTypes::WHEAT}};
-    HarvestTile tl{type1};
-    HarvestTile tr{type2};
-    HarvestTile bl{type3};
-    HarvestTile br{type4};
     switch((*CONFIG)){
         case 0:
             /*

--- a/NewHaven/src/GBMap.h
+++ b/NewHaven/src/GBMap.h
@@ -27,7 +27,7 @@ public:
     static GBMap *current_map;
     const int* const CONFIG;
     const int * const SIZE;
-    bool placeHarvestTile(int NodeID,HarvestTile &tile);
+    bool placeHarvestTile(int NodeID,HarvestTile *tile);
     ResourceTrails* getResourcedGraph(int position);
     void printBoard();
     void printIndexConfiguration();
@@ -35,8 +35,11 @@ public:
     Building* drawBuildingFromBoard(int position);
     GameBoard* board;
 private:
-
     std::vector<Building*>* buildings;
+    HarvestTile *tl{new HarvestTile(new ResourceTypes[4]{ResourceTypes::STONE, ResourceTypes ::SHEEP, ResourceTypes::WOOD, ResourceTypes::WOOD})};
+    HarvestTile *tr{new HarvestTile(new ResourceTypes[4]{ResourceTypes::WHEAT, ResourceTypes ::SHEEP, ResourceTypes::WHEAT, ResourceTypes::WOOD})};
+    HarvestTile *bl{new HarvestTile(new ResourceTypes[4]{ResourceTypes::SHEEP, ResourceTypes ::STONE, ResourceTypes::SHEEP, ResourceTypes::WHEAT})};
+    HarvestTile *br{new HarvestTile(new ResourceTypes[4]{ResourceTypes::STONE, ResourceTypes ::STONE, ResourceTypes::WOOD, ResourceTypes::WHEAT})};
     bool createBoard();
     inline void resetVisitedNodes();
     inline bool vertexContainedInQueue(deque<NodeID> queue, NodeID element) const;

--- a/NewHaven/src/Player.cpp
+++ b/NewHaven/src/Player.cpp
@@ -151,7 +151,7 @@ int Player::placeHarvestTile() {
 
     // later this will be called from the singleton Game Controller
     if(GBMap::current_map != nullptr) {
-        if(GBMap::current_map->placeHarvestTile(pos, *(*my_hand->harvestTiles)[index_tile])) {
+        if(GBMap::current_map->placeHarvestTile(pos, (*my_hand->harvestTiles)[index_tile])) {
             my_hand->harvestTiles->erase(my_hand->harvestTiles->begin() + index_tile);
             return pos;
         } else{
@@ -172,7 +172,7 @@ int Player::placeShipmentTile() {
 
     // later this will be called from the singleton Game Controller
     if(GBMap::current_map != nullptr) {
-        if(GBMap::current_map->placeHarvestTile(pos, *(*my_hand->harvestTiles).back())) {
+        if(GBMap::current_map->placeHarvestTile(pos, (*my_hand->harvestTiles).back())) {
             my_hand->harvestTiles->erase(my_hand->harvestTiles->end());
             return pos;
         }


### PR DESCRIPTION
Fixes a potential source of memory leak when assigning the default HarvestTiles to the map.
Also switched placeHarvestTile to accept a pointer to avoid assigning a copy. 

May require other dependent code to do small tweaks

Can use Part1 to test and make sure no crashes