### PR TITLE
Fixes ~30 of the memory leak occurrences according to valgrind

### DIFF
--- a/NewHaven/src/GBMapLoader.cpp
+++ b/NewHaven/src/GBMapLoader.cpp
@@ -11,6 +11,24 @@
 #include "../Exceptions/InvalidConfigurationException.h"
 
 using namespace std;
+
+GBMapLoader::GBMapLoader(){}
+GBMapLoader::GBMapLoader(const GBMapLoader &loader) {
+    *game_board_configuration = *loader.game_board_configuration;
+}
+
+GBMapLoader & GBMapLoader::operator=(const GBMapLoader &loader) {
+    if(&loader == this)
+        return *this;
+
+    *game_board_configuration = *loader.game_board_configuration;
+
+    return *this;
+}
+
+GBMapLoader::~GBMapLoader() {
+    delete game_board_configuration;
+}
 // Reads filepath and returns true if the board was creation. It will either return false or an exception if it fails.
 bool GBMapLoader::loadConfig(std::string filepath) {
 
@@ -58,8 +76,7 @@ bool GBMapLoader::loadConfig(std::string filepath) {
 // create a GBMap, set its configuration and generate the graph before returning it.
 GBMap* GBMapLoader::generateMap() {
     if(*game_board_configuration != -1){
-        GBMap *gb_map{new GBMap(*game_board_configuration)};
-        return gb_map;
+        return new GBMap(*game_board_configuration);
     }
     else{
         throw BoardConfigurationNotLoaded();

--- a/NewHaven/src/GBMapLoader.h
+++ b/NewHaven/src/GBMapLoader.h
@@ -10,6 +10,10 @@
 #include "GBMap.h"
 class GBMapLoader {
 public:
+    GBMapLoader();
+    GBMapLoader(const GBMapLoader & loader);
+    GBMapLoader& operator=(const GBMapLoader & loader);
+    ~GBMapLoader();
     bool loadConfig(std::string filepath);
     GBMap* generateMap();
 

--- a/NewHaven/src/GameController.cpp
+++ b/NewHaven/src/GameController.cpp
@@ -101,6 +101,7 @@ void GameController::playTurn(){
             pos=current->placeHarvestTile();
             ResourceTrails *trail = game_settings->board->getResourcedGraph(pos);
             game_settings->tracker->computeScore(*trail);
+            delete trail;
         }
             // play the shipmentTile
         else if(tile_option == 2){

--- a/NewHaven/src/Player.cpp
+++ b/NewHaven/src/Player.cpp
@@ -157,22 +157,29 @@ int Player::placeHarvestTile() {
     cout << "\nHere is a combination of rotations possible for your tile:\n";
     // show possible tile positions
     HarvestTile * tile = (*my_hand->harvestTiles)[index_tile-1];
+    ResourceTypes *types = tile->getTileContent();
     // position 1 --> default
-    cout << "\n1:\t" << tile->getTileContent()[0] << '\t' <<tile->getTileContent()[1] << endl;
-    cout << "  \t" << tile->getTileContent()[3] << '\t' << tile->getTileContent()[2] << endl << endl;
+    cout << "\n1:\t" <<types[0] << '\t' <<types[1] << endl;
+    cout << "  \t" << types[3] << '\t' << types[2] << endl << endl;
+    delete types;
     // position 2 -->
     tile->rotateTileClockwise();
-    cout << "2:\t" << tile->getTileContent()[0] << '\t' <<tile->getTileContent()[1] << endl;
-    cout << "  \t" << tile->getTileContent()[3] << '\t' << tile->getTileContent()[2] << endl << endl;
+    types = tile->getTileContent();;
+    cout << "2:\t" <<types[0] << '\t' <<types[1] << endl;
+    cout << "  \t" << types[3] << '\t' << types[2] << endl << endl;
+    delete types;
     // position 3
     tile->rotateTileClockwise();
-    cout << "3:\t" << tile->getTileContent()[0] << '\t' <<tile->getTileContent()[1] << endl;
-    cout << "  \t" << tile->getTileContent()[3] << '\t' << tile->getTileContent()[2] << endl << endl;
+    types = tile->getTileContent();;
+    cout << "3:\t" << types[0] << '\t' <<types[1] << endl;
+    cout << "  \t" << types[3] << '\t' << types[2] << endl << endl;
+    delete types;
     // position 4
     tile->rotateTileClockwise();
-    cout << "4:\t" << tile->getTileContent()[0] << '\t' <<tile->getTileContent()[1] << endl;
-    cout << "  \t" << tile->getTileContent()[3] << '\t' << tile->getTileContent()[2] << endl << endl;
-
+    types = tile->getTileContent();;
+    cout << "4:\t" << types[0] << '\t' <<types[1] << endl;
+    cout << "  \t" << types[3] << '\t' << types[2] << endl << endl;
+    delete types;
 
     while( (cout << "Choice: " && !(cin >> choice_rot)) || choice_rot < 0 || choice_rot > 4){
         cin.clear(); // reset failbit

--- a/NewHaven/src/ResourceTracker.cpp
+++ b/NewHaven/src/ResourceTracker.cpp
@@ -46,7 +46,7 @@ void ResourceTracker::computeScore(ResourceTrails trail) {
     NodeID root = vertices[0];
     // Add the starting resources from the root to the count?
     queue.push_back(root);
-    ResourceTypes *r_resources{(*trail[root].tile).getTileContent()};
+    ResourceTypes *r_resources{(*trail[root].tile).tileContent};
     Quad *quad = new Quad();
             for(int i = 0; i < 4; i++){
                ResourceTypes resource{r_resources[i]};
@@ -61,12 +61,12 @@ void ResourceTracker::computeScore(ResourceTrails trail) {
         // now we build the queues
         ResourceTrails::adjacency_iterator neighbourIt, neighbourEnd;
 
-        ResourceTypes *root_resources{(*trail[root].tile).getTileContent()};
+        ResourceTypes *root_resources{(*trail[root].tile).tileContent};
         for (tie(neighbourIt, neighbourEnd) = adjacent_vertices(root, trail); neighbourIt != neighbourEnd; ++neighbourIt) {
             // get ourselves our vertex
             Quad *next_quad;
             NodeID next_element{vertices[*neighbourIt]};
-            ResourceTypes *next_resources{(*trail[next_element].tile).getTileContent()};
+            ResourceTypes *next_resources{(*trail[next_element].tile).tileContent};
             // compare index 2 of root to index 0 of next element
             if(map.find(next_element) != map.end())
                 next_quad = map[next_element];
@@ -269,7 +269,7 @@ void ResourceTracker::backstepping(NodeID root, Map *map, ResourceTrails &trail)
     auto vertices{trail.vertex_set()};
     // now we build the queues
    ResourceTrails ::adjacency_iterator neighbourIt, neighbourEnd;
-    ResourceTypes *root_resources{(*trail[root].tile).getTileContent()};
+    ResourceTypes *root_resources{(*trail[root].tile).tileContent};
     for ( tie(neighbourIt, neighbourEnd) = adjacent_vertices(root, trail); neighbourIt != neighbourEnd; ++neighbourIt) {
         // get ourselves our vertex
         NodeID next_element{vertices[*neighbourIt]};

--- a/NewHaven/src/VGMap.cpp
+++ b/NewHaven/src/VGMap.cpp
@@ -30,10 +30,10 @@ VGMap::~VGMap() {
     delete name;
     delete SIZE;
     delete playCounter;
+    delete typePlayed;
 }
 
 VGMap::VGMap(const VGMap &map) {
-    if(map.village_board !=nullptr)
     village_board = new C_Graph(*map.village_board);
     typePlayed = new  std::map<ResourceTypes, bool>(*map.typePlayed);
     // here we can use operator overload

--- a/NewHaven/src/VGMapLoader.cpp
+++ b/NewHaven/src/VGMapLoader.cpp
@@ -10,6 +10,24 @@
 #include "../Exceptions/InvalidConfigurationException.h"
 
 using namespace std;
+
+VGMapLoader::VGMapLoader(){}
+VGMapLoader::VGMapLoader(const VGMapLoader &loader) {
+    *name = *loader.name;
+}
+
+VGMapLoader & VGMapLoader::operator=(const VGMapLoader &loader) {
+    if(&loader == this)
+        return *this;
+
+    *name = *loader.name;
+
+    return *this;
+}
+
+VGMapLoader::~VGMapLoader() {
+    delete name;
+}
 // Reads filepath and returns true if the board was creation. It will either return false or an exception if it fails.
 bool VGMapLoader::loadVConfig(std::string filepath) {
 

--- a/NewHaven/src/VGMapLoader.h
+++ b/NewHaven/src/VGMapLoader.h
@@ -9,6 +9,10 @@
 
 class VGMapLoader {
 public:
+    VGMapLoader();
+    VGMapLoader(const VGMapLoader & loader);
+    VGMapLoader& operator=(const VGMapLoader & loader);
+    ~VGMapLoader();
     bool loadVConfig(std::string filepath);
     VGMap generateVMap();
 


### PR DESCRIPTION
~6 remain (all are instances have one of two origins) 
Don't know what is causing the leak or how resolve it. 
The loaders were missing copy constructors/ assignment overload and destructor! Others are related to getTileContent()